### PR TITLE
Change nokogiri version to avoid install error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.0.0)
     mustermann (1.0.3)
-    nokogiri (1.8.4)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     os (1.0.0)
     public_suffix (3.0.3)


### PR DESCRIPTION
- nokogiriインストール中にこんなエラーが出ていた。

```Fetching nokogiri 1.8.4
Installing nokogiri 1.8.4 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/rbenv/versions/2.5.1/lib/x86_64-linux-gnu/ruby/gems/2.5.0/gems/nokogiri-1.8.4/ext/nokogiri
/rbenv/versions/2.5.1/bin/ruby -r ./siteconf20180927-5-1xx50xd.rb extconf.rb
checking if the C compiler accepts ... yes
Building nokogiri using system libraries.
pkg-config could not be used to find libxml-2.0
Please install either `pkg-config` or the pkg-config gem per

gem install pkg-config -v "~> 1.1"

pkg-config could not be used to find libxslt
Please install either `pkg-config` or the pkg-config gem per

gem install pkg-config -v "~> 1.1"

pkg-config could not be used to find libexslt
Please install either `pkg-config` or the pkg-config gem per

gem install pkg-config -v "~> 1.1"

ERROR: cannot discover where libxml2 is located on your system. please make sure
`pkg-config` is installed.
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers. Check the mkmf.log file for more details. You may
need configuration options.

Provided configuration options:
--with-opt-dir
--without-opt-dir
--with-opt-include
--without-opt-include=${opt-dir}/include
--with-opt-lib
--without-opt-lib=${opt-dir}/lib
--with-make-prog
--without-make-prog
--srcdir=.
--curdir
--ruby=/rbenv/versions/2.5.1/bin/$(RUBY_BASE_NAME)
--help
--clean
--use-system-libraries=true
--with-zlib-dir
--without-zlib-dir
--with-zlib-include
--without-zlib-include=${zlib-dir}/include
--with-zlib-lib
--without-zlib-lib=${zlib-dir}/lib
--with-xml2-dir
--without-xml2-dir
--with-xml2-include
--without-xml2-include=${xml2-dir}/include
--with-xml2-lib
--without-xml2-lib=${xml2-dir}/lib
--with-libxml-2.0-config
--without-libxml-2.0-config
--with-pkg-config
--without-pkg-config
--with-xslt-dir
--without-xslt-dir
--with-xslt-include
--without-xslt-include=${xslt-dir}/include
--with-xslt-lib
--without-xslt-lib=${xslt-dir}/lib
--with-libxslt-config
--without-libxslt-config
--with-exslt-dir
--without-exslt-dir
--with-exslt-include
--without-exslt-include=${exslt-dir}/include
--with-exslt-lib
--without-exslt-lib=${exslt-dir}/lib
--with-libexslt-config
--without-libexslt-config

To see why this extension failed to compile, please check the mkmf.log which can
be found here:

/rbenv/versions/2.5.1/lib/x86_64-linux-gnu/ruby/gems/2.5.0/extensions/x86_64-linux/2.5.0-static/nokogiri-1.8.4/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in
/rbenv/versions/2.5.1/lib/x86_64-linux-gnu/ruby/gems/2.5.0/gems/nokogiri-1.8.4
for inspection.
Results logged to
/rbenv/versions/2.5.1/lib/x86_64-linux-gnu/ruby/gems/2.5.0/extensions/x86_64-linux/2.5.0-static/nokogiri-1.8.4/gem_make.out

An error occurred while installing nokogiri (1.8.4), and Bundler cannot
continue.
Make sure that `gem install nokogiri -v '1.8.4'` succeeds before bundling.```

- これはバージョン依存で起きているらしく最新の`1.8.4`では起きていて`1.8.2`は起きていなかったため`1.8.2`に変更(`1.8.2`以降がすべて起きない訳でもない)