### PR TITLE
Ensure that timezone is set Asia/Tokyo

### DIFF
--- a/lib/chunithm_recoder.rb
+++ b/lib/chunithm_recoder.rb
@@ -6,6 +6,7 @@ require 'time'
 
 class ChunithmRecorder
   def initialize
+    ENV['TZ'] = 'Asia/Tokyo'
     Dotenv.load
     @options = Selenium::WebDriver::Chrome::Options.new
     @options.add_argument('--headless')


### PR DESCRIPTION
- `load`の引数に与えられる時刻が実行環境に依存していたので`Asia/Tokyo`に固定